### PR TITLE
add High-Performance order storage support

### DIFF
--- a/woocommerce-rewardful.php
+++ b/woocommerce-rewardful.php
@@ -71,3 +71,9 @@ function run_woocommerce_rewardful() {
 
 }
 run_woocommerce_rewardful();
+
+add_action( 'before_woocommerce_init', function() {
+    if ( class_exists( \Automattic\WooCommerce\Utilities\FeaturesUtil::class ) ) {
+        \Automattic\WooCommerce\Utilities\FeaturesUtil::declare_compatibility( 'custom_order_tables', __FILE__, true );
+    }
+} );


### PR DESCRIPTION
This fixes #1 to support Woocommerce High-Performance Storage.